### PR TITLE
Remove redundant section from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,11 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>app-sre/shared-pipelines//renovate/default.json"
-  ],
-  "packageRules": [
-    {
-      "matchPackageNames": ["pytest**"],
-      "groupName": "pytest"
-    }
   ]
 }


### PR DESCRIPTION
It is already defined in the shared-pipelines one